### PR TITLE
Export to HTML feature, several bug-fixes

### DIFF
--- a/content/markdown-viewer.js
+++ b/content/markdown-viewer.js
@@ -117,20 +117,20 @@ extensions.markdown = {};
         var mwindow = mdocument.ownerGlobal;
 
         // Set markdown options.
-        //if (!mwindow.setMarkedOptions) {
-        //    mwindow.setMarkedOptions = true;
-        //    // TODO: Could be exposed as user preferences.
-        //    mwindow.marked.setOptions({
-        //        renderer: new mwindow.marked.Renderer(),
-        //        gfm: true,
-        //        tables: true,
-        //        breaks: false,
-        //        pedantic: false,
-        //        sanitize: true,
-        //        smartLists: true,
-        //        smartypants: false,
-        //    });
-        //}
+        if (!mwindow.setMarkedOptions) {
+            mwindow.setMarkedOptions = true;
+            // TODO: Could be exposed as user preferences.
+            mwindow.marked.setOptions({
+                renderer: new mwindow.marked.Renderer(),
+                gfm: true,
+                tables: true,
+                breaks: false,
+                pedantic: true,
+                sanitize: false,
+                smartLists: true,
+                smartypants: false,
+            });
+        }
 
         // Generate and load markdown html into the browser view.
         var mwrap = mdocument.getElementById("wrap");

--- a/content/markdown-viewer.js
+++ b/content/markdown-viewer.js
@@ -43,7 +43,9 @@ extensions.markdown = {};
         }
         var editor = view.scintilla;
         var x = getXPosition(this.panel, editor);
-        this.panel.openPopup(editor, null, x, 0);
+        var editorBox = editor.boxObject;
+        this.panel.openPopup(editor, null, editorBox.screenX + x, editorBox.screenY);
+        this.panel.moveTo(editorBox.screenX + x, editorBox.screenY);
     }
 
     this.hidePopup = function() {
@@ -183,7 +185,7 @@ extensions.markdown = {};
             }
 
             // TODO: Need a way to detect that a view has been resized!
-            //window.addEventListener("resize", this.onviewresize.bind(this));
+            window.addEventListener("resize", this.onviewresize.bind(this));
             this.onviewchanged();
         } catch (ex) {
             log.exception(ex);

--- a/content/markdown-viewer.js
+++ b/content/markdown-viewer.js
@@ -169,13 +169,13 @@ extensions.markdown = {};
         // Wait till the browser is loaded.
         if (mdocument.readyState != 'complete') {
             updatepreview_timeout_id = setTimeout(this.updatePreview.bind(this, view), 50);
+            return;
         }
         
         // Change the tab label.
         mdocument.title = view.title + ' (preview)';
 
         var mwindow = mdocument.ownerGlobal;
-        if (!mwindow.marked) return;
 
         // Set markdown options.
         if (!mwindow.setMarkedOptions) {
@@ -247,7 +247,6 @@ extensions.markdown = {};
                                   { label: "Markdown: Generate markdown preview" });
             }
 
-            // TODO: Need a way to detect that a view has been resized!
             window.addEventListener("resize", this.onviewresize.bind(this));
             this.onviewchanged();
         } catch (ex) {

--- a/content/markdown-viewer.js
+++ b/content/markdown-viewer.js
@@ -99,10 +99,6 @@ extensions.markdown = {};
         var settings = this.getSettings(view);
         settings.previewing = true;
         view.preview = null;
-
-        // Change the tab label:
-        markdown_view.title = "Markdown - " + view.title;
-
         this.updatePreview(view);
     }
 
@@ -112,8 +108,11 @@ extensions.markdown = {};
 
         // Wait till the browser is loaded.
         if (mdocument.readyState != 'complete') {
-            return setTimeout(this.updatePreview.bind(this, view), 50);
+            updatepreview_timeout_id = setTimeout(this.updatePreview.bind(this, view), 50);
         }
+        
+        // Change the tab label.
+        mdocument.title = view.title + ' (preview)';
 
         var mwindow = mdocument.ownerGlobal;
 

--- a/content/markdown-viewer.js
+++ b/content/markdown-viewer.js
@@ -138,7 +138,7 @@ extensions.markdown = {};
         mwrap.innerHTML = mwindow.marked(text);
 
         // Highlight the code sections.
-        var blocks = mdocument.querySelectorAll('pre code');
+        var blocks = mdocument.querySelectorAll('code[class^=lang-]');
         Array.prototype.forEach.call(blocks, mwindow.hljs.highlightBlock);
     }
 

--- a/content/overlay.xul
+++ b/content/overlay.xul
@@ -15,7 +15,7 @@
                ignorekeys="true"
                level="parent">
             <vbox>
-                <hbox>
+                <vbox>
                     <button id="extension_markdown_button"
                             type="menu-button"
                             label="Preview"
@@ -31,7 +31,12 @@
                                       oncommand="extensions.markdown.onpreview(event, 'horizontal');" />
                         </menupopup>
                     </button>
-                </hbox>
+                    <button id="extension_markdown_export_button"
+                            type="button"
+                            label="To HTML"
+                            oncommand="extensions.markdown.onpreview(event, null, true);">
+                    </button>
+                </vbox>
             </vbox>
         </panel>
     </popupset>

--- a/content/overlay.xul
+++ b/content/overlay.xul
@@ -31,9 +31,19 @@
                     </menupopup>
                 </button>
                 <button id="extension_markdown_export_button"
-                        type="button"
+                        type="menu-button"
                         label="To HTML"
                         oncommand="extensions.markdown.onexport(event);">
+                    <menupopup>
+                        <menuitem label="As a new editor file"
+                                  type="radio"
+                                  name="extension_markdown_radio_export"
+                                  oncommand="extensions.markdown.onexport(event, 'file');" />
+                        <menuitem label="To clipboard"
+                                  type="radio"
+                                  name="extension_markdown_radio_export"
+                                  oncommand="extensions.markdown.onexport(event, 'clipboard');" />
+                    </menupopup>
                 </button>
             </vbox>
         </panel>

--- a/content/overlay.xul
+++ b/content/overlay.xul
@@ -13,7 +13,7 @@
                noautofocus="true"
                noautohide="true"
                ignorekeys="true"
-               level="floating">
+               level="parent">
             <vbox>
                 <hbox>
                     <button id="extension_markdown_button"

--- a/content/overlay.xul
+++ b/content/overlay.xul
@@ -15,28 +15,26 @@
                ignorekeys="true"
                level="parent">
             <vbox>
-                <vbox>
-                    <button id="extension_markdown_button"
-                            type="menu-button"
-                            label="Preview"
-                            oncommand="extensions.markdown.onpreview(event);">
-                        <menupopup>
-                            <menuitem label="Under-over split view"
-                                      type="radio"
-                                      name="extension_markdown_radio_splitview"
-                                      oncommand="extensions.markdown.onpreview(event, 'vertical');" />
-                            <menuitem label="Side-by-side split view"
-                                      type="radio"
-                                      name="extension_markdown_radio_splitview"
-                                      oncommand="extensions.markdown.onpreview(event, 'horizontal');" />
-                        </menupopup>
-                    </button>
-                    <button id="extension_markdown_export_button"
-                            type="button"
-                            label="To HTML"
-                            oncommand="extensions.markdown.onpreview(event, null, true);">
-                    </button>
-                </vbox>
+                <button id="extension_markdown_button"
+                        type="menu-button"
+                        label="Preview"
+                        oncommand="extensions.markdown.onpreview(event);">
+                    <menupopup>
+                        <menuitem label="Under-over split view"
+                                  type="radio"
+                                  name="extension_markdown_radio_splitview"
+                                  oncommand="extensions.markdown.onpreview(event, 'vertical');" />
+                        <menuitem label="Side-by-side split view"
+                                  type="radio"
+                                  name="extension_markdown_radio_splitview"
+                                  oncommand="extensions.markdown.onpreview(event, 'horizontal');" />
+                    </menupopup>
+                </button>
+                <button id="extension_markdown_export_button"
+                        type="button"
+                        label="To HTML"
+                        oncommand="extensions.markdown.onexport(event);">
+                </button>
             </vbox>
         </panel>
     </popupset>

--- a/content/template.html
+++ b/content/template.html
@@ -9,6 +9,6 @@
     <link rel="stylesheet" href="chrome://markdown-viewer/content/contrib/highlight/styles/github.css">
 </head>
 <body>
-    <article class="markdown-body" id="wrap"></article>
+    <div class="markdown-body" id="wrap"></div>
 </body>
 </html>

--- a/tests/github-test.md
+++ b/tests/github-test.md
@@ -1,0 +1,327 @@
+# GitHub MD syntax test
+
+This is intended as a quick reference and showcase. For more complete info, see
+[John Gruber's original spec](http://daringfireball.net/projects/markdown/)
+and the [Github-flavored Markdown info page](http://github.github.com/github-flavored-markdown/).
+
+## 1. Headers
+
+    # H1
+    ## H2
+    ### H3
+    #### H4
+    ##### H5
+    ###### H6
+    
+    Alternatively, for H1 and H2, an underline-ish style:
+    
+    Alt-H1
+    ======
+    
+    Alt-H2
+    ------
+
+# H1
+## H2
+### H3
+#### H4
+##### H5
+###### H6
+
+Alternatively, for H1 and H2, an underline-ish style:
+
+Alt-H1
+======
+
+Alt-H2
+------
+
+## 2. Emphasis
+
+    Emphasis, aka italics, with *asterisks* or _underscores_.
+    
+    Strong emphasis, aka bold, with **asterisks** or __underscores__.
+    
+    Combined emphasis with **asterisks and _underscores_**.
+    
+    Strikethrough uses two tildes. ~~Scratch this.~~
+
+
+Emphasis, aka italics, with *asterisks* or _underscores_.
+
+Strong emphasis, aka bold, with **asterisks** or __underscores__.
+
+Combined emphasis with **asterisks and _underscores_**.
+
+Strikethrough uses two tildes. ~~Scratch this.~~
+
+
+## 3. Lists
+
+(In this example, leading and trailing spaces are shown with with dots: ⋅)
+
+```markdown
+1. First ordered list item
+2. Another item
+⋅⋅* Unordered sub-list. 
+1. Actual numbers don't matter, just that it's a number
+⋅⋅1. Ordered sub-list
+4. And another item.
+
+⋅⋅⋅You can have properly indented paragraphs within list items. Notice the blank line above, and the leading spaces (at least one, but we'll use three here to also align the raw Markdown).
+
+⋅⋅⋅To have a line break without a paragraph, you will need to use two trailing spaces.⋅⋅
+⋅⋅⋅Note that this line is separate, but within the same paragraph.⋅⋅
+⋅⋅⋅(This is contrary to the typical GFM line break behaviour, where trailing spaces are not required.)
+
+* Unordered list can use asterisks
+- Or minuses
++ Or pluses
+```
+
+1. First ordered list item
+2. Another item
+  * Unordered sub-list. 
+1. Actual numbers don't matter, just that it's a number
+  1. Ordered sub-list
+4. And another item.
+
+   You can have properly indented paragraphs within list items. Notice the blank line above, and the leading spaces (at least one, but we'll use three here to also align the raw Markdown).
+
+   To have a line break without a paragraph, you will need to use two trailing spaces.  
+   Note that this line is separate, but within the same paragraph.  
+   (This is contrary to the typical GFM line break behaviour, where trailing spaces are not required.)
+
+* Unordered list can use asterisks
+- Or minuses
++ Or pluses
+
+## 4. Links
+
+```markdown
+[I'm an inline-style link](https://www.google.com)
+
+[I'm an inline-style link with title](https://www.google.com "Google's Homepage")
+
+[I'm a reference-style link][Arbitrary case-insensitive reference text]
+
+[I'm a relative reference to a repository file](../blob/master/LICENSE)
+
+[You can use numbers for reference-style link definitions][1]
+
+Or leave it empty and use the [link text itself]
+
+Some text to show that the reference links can follow later.
+
+[arbitrary case-insensitive reference text]: https://www.mozilla.org
+[1]: http://slashdot.org
+[link text itself]: http://www.reddit.com
+```
+
+[I'm an inline-style link](https://www.google.com)
+
+[I'm an inline-style link with title](https://www.google.com "Google's Homepage")
+
+[I'm a reference-style link][Arbitrary case-insensitive reference text]
+
+[I'm a relative reference to a repository file](../blob/master/LICENSE)
+
+[You can use numbers for reference-style link definitions][1]
+
+Or leave it empty and use the [link text itself]
+
+Some text to show that the reference links can follow later.
+
+[arbitrary case-insensitive reference text]: https://www.mozilla.org
+[1]: http://slashdot.org
+[link text itself]: http://www.reddit.com
+
+## 5. Images
+
+```markdown
+Here's our logo (hover to see the title text):
+
+Inline-style: 
+![alt text](https://github.com/adam-p/markdown-here/raw/master/src/common/images/icon48.png "Logo Title Text 1")
+
+Reference-style: 
+![alt text][logo]
+
+[logo]: https://github.com/adam-p/markdown-here/raw/master/src/common/images/icon48.png "Logo Title Text 2"
+```
+
+Here's our logo (hover to see the title text):
+
+Inline-style: 
+![alt text](https://github.com/adam-p/markdown-here/raw/master/src/common/images/icon48.png "Logo Title Text 1")
+
+Reference-style: 
+![alt text][logo]
+
+[logo]: https://github.com/adam-p/markdown-here/raw/master/src/common/images/icon48.png "Logo Title Text 2"
+
+## 6. Code and Syntax Highlighting
+
+There actually should be backticks instead of single quote characters.
+
+```markdown
+'''javascript
+var s = "JavaScript syntax highlighting";
+alert(s);
+'''
+ 
+'''python
+s = "Python syntax highlighting"
+print s
+'''
+ 
+
+'''html
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Test</title>
+    </head>
+    <body>
+        <h1>Hello world!</h1>
+    </body>
+</html>
+'''
+
+'''
+No language indicated, so no syntax highlighting. 
+But let's throw in a <b>tag</b>.
+'''
+```
+
+```javascript
+var s = "JavaScript syntax highlighting";
+alert(s);
+```
+ 
+```python
+s = "Python syntax highlighting"
+print s
+```
+ 
+```html
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Test</title>
+    </head>
+    <body>
+        <h1>Hello world!</h1>
+    </body>
+</html>
+```
+
+```css
+div { position: absolute }
+div.test {
+    background-image: url("image.png");
+    background-repeat: no-repeat;
+}
+```
+
+```
+No language indicated, so no syntax highlighting. 
+But let's throw in a <b>tag</b>.
+```
+
+
+## 7. Tables
+
+```markdown
+| Tables        | Are           | Cool  |
+| ------------- |:-------------:| -----:|
+| col 3 is      | right-aligned | $1600 |
+| col 2 is      | centered      |   $12 |
+| zebra stripes | are neat      |    $1 |
+
+Markdown | Less | Pretty
+--- | --- | ---
+*Still* | `renders` | **nicely**
+1 | 2 | 3
+```
+
+| Tables        | Are           | Cool  |
+| ------------- |:-------------:| -----:|
+| col 3 is      | right-aligned | $1600 |
+| col 2 is      | centered      |   $12 |
+| zebra stripes | are neat      |    $1 |
+
+Markdown | Less | Pretty
+--- | --- | ---
+*Still* | `renders` | **nicely**
+1 | 2 | 3
+
+## 8. Blockquotes
+
+```markdown
+> Blockquotes are very handy in email to emulate reply text.
+> This line is part of the same quote.
+
+Quote break.
+
+> This is a very long line that will still be quoted properly when it wraps. Oh boy let's keep writing to make sure this is long enough to actually wrap for everyone. Oh, you can *put* **Markdown** into a blockquote. 
+```
+
+> Blockquotes are very handy in email to emulate reply text.
+> This line is part of the same quote.
+
+Quote break.
+
+> This is a very long line that will still be quoted properly when it wraps. Oh boy let's keep writing to make sure this is long enough to actually wrap for everyone. Oh, you can *put* **Markdown** into a blockquote.
+
+## 9. Inline HTML
+
+```markdown
+<dl>
+  <dt>Definition list</dt>
+  <dd>Is something people use sometimes.</dd>
+
+  <dt>Markdown in HTML</dt>
+  <dd>Does *not* work **very** well. Use HTML <em>tags</em>.</dd>
+</dl>
+```
+
+<dl>
+  <dt>Definition list</dt>
+  <dd>Is something people use sometimes.</dd>
+  
+  <dt>Markdown in HTML</dt>
+  <dd>Does *not* work **very** well. Use HTML <em>tags</em>.</dd>
+</dl>
+
+## 10. Horizontal Rule
+
+```markdown
+Three or more...
+
+---
+
+Hyphens
+
+***
+
+Asterisks
+
+___
+
+Underscores
+```
+
+Three or more...
+
+---
+
+Hyphens
+
+***
+
+Asterisks
+
+___
+
+Underscores


### PR DESCRIPTION
# New feature: export to HTML

I added "To HTML" button under the "Preview" button.

First it renders the preview, but it's invisible, because new editor window is opened in its place and the well-formed HTML5 representation of markdown file is placed in it. The file contains all necessary styles and displays correctly in most modern browsers.
# Bugs fixed:
- incorrect preview button position on multi-monitor configuration,
- lack of preview button repositioning on editor window resize event,
- minor rendering bugs (incompatibilities with GitHub John Gruber's markdown flavour).
# Minor changes:
- changed preview wrapper element from article to div to make it more semantically correct.
# Comments:
- i'm not sure if `ko.views.manager._doNewView('HTML5', null)` is completely valid and compatible way of creating new HTML5 file tab.
